### PR TITLE
Removes Kelli from assignees

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,8 @@ about: Create a report to help us eliminate bugs
 title: ''
 labels: ["type: bug"]
 assignees:
-  - kellijohnson-NOAA
+  - chantelwetzel-NOAA
+  - iantaylor-NOAA
 ---
 
 **Describe the bug**

--- a/.github/ISSUE_TEMPLATE/data-request.yml
+++ b/.github/ISSUE_TEMPLATE/data-request.yml
@@ -4,7 +4,6 @@ description: >
 title: "Data request for species <replace with your species>"
 labels: ["type: request", "topic: database"]
 assignees:
-  - kellijohnson-NOAA
   - chantelwetzel-NOAA
 body:
   - type: markdown


### PR DESCRIPTION
I realized that I was still automatically assigned to issues when the recent data request came through. This removes me from the issues and adds Ian and Chantel to bugs that are posted.

Bug - Ian and Chantel were added
Data - Kelli was removed and only Chantel remains