### PR TITLE
add ODFW age method 11

### DIFF
--- a/R/codify_age_method.R
+++ b/R/codify_age_method.R
@@ -23,6 +23,7 @@
 #' * 6-length;
 #' * 9-unable;
 #' * 10-break and bake;
+#' * 11-break and bake and burn;
 #'
 #'  ## California Department of Fish and Wildlife
 #' * B-break and burn;
@@ -56,6 +57,7 @@ codify_age_method <- function(x) {
     x == "L" ~ "L",
     x == "M" ~ "M",
     x == 10 ~ "B",
+    x == 11 ~ "B",
     x %in% all_NA ~ NA_character_,
     is.na(x) ~ NA_character_,
     TRUE ~ NA_character_

--- a/man/codify_age_method.Rd
+++ b/man/codify_age_method.Rd
@@ -40,6 +40,7 @@ and burn can be "B", "BB", or 1.
 \item 6-length;
 \item 9-unable;
 \item 10-break and bake;
+\item 11-break and bake and burn;
 }
 }
 


### PR DESCRIPTION
I just learned from @gertsevv that many Rougheye/Blackspotted samples use ODFW ageing method code 11 in PacFIN.

Mark Terwilliger said by email just now that "Ageing method 11 is a combination of break and bake and then a burn. All the rougheye are break and bake, then during the course of ageing if I feel they need some more heat (or if they have faded during second reads), I’ll put them over the flame. It helps clear up glassiness in the samples."

Changes in this pull request should allow the package to correctly assign these to "B" as a variation of break and burn.